### PR TITLE
small_data_for_discriminator_error

### DIFF
--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -121,7 +121,7 @@ pub fn base58_encode(data: &RecordBatch) -> Result<RecordBatch> {
     let mut columns = Vec::<Arc<dyn Array>>::with_capacity(data.columns().len());
 
     for col in data.columns().iter() {
-        if col.data_type() == &DataType::Binary || col.data_type() == &DataType::LargeBinary {
+        if col.data_type() == &DataType::Binary {
             columns.push(Arc::new(base58_encode_column(
                 col.as_any().downcast_ref::<BinaryArray>().unwrap(),
             )));
@@ -157,7 +157,7 @@ pub fn hex_encode<const PREFIXED: bool>(data: &RecordBatch) -> Result<RecordBatc
     let mut columns = Vec::<Arc<dyn Array>>::with_capacity(data.columns().len());
 
     for col in data.columns().iter() {
-        if col.data_type() == &DataType::Binary || col.data_type() == &DataType::LargeBinary {
+        if col.data_type() == &DataType::Binary {
             columns.push(Arc::new(hex_encode_column::<PREFIXED>(
                 col.as_any().downcast_ref::<BinaryArray>().unwrap(),
             )));
@@ -200,7 +200,7 @@ pub fn schema_binary_to_string(schema: &Schema) -> Schema {
     let mut fields = Vec::<Arc<Field>>::with_capacity(schema.fields().len());
 
     for f in schema.fields().iter() {
-        if f.data_type() == &DataType::Binary || f.data_type() == &DataType::LargeBinary {
+        if f.data_type() == &DataType::Binary {
             fields.push(Arc::new(Field::new(
                 f.name().clone(),
                 DataType::Utf8,

--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -121,7 +121,7 @@ pub fn base58_encode(data: &RecordBatch) -> Result<RecordBatch> {
     let mut columns = Vec::<Arc<dyn Array>>::with_capacity(data.columns().len());
 
     for col in data.columns().iter() {
-        if col.data_type() == &DataType::Binary {
+        if col.data_type() == &DataType::Binary || col.data_type() == &DataType::LargeBinary {
             columns.push(Arc::new(base58_encode_column(
                 col.as_any().downcast_ref::<BinaryArray>().unwrap(),
             )));
@@ -157,7 +157,7 @@ pub fn hex_encode<const PREFIXED: bool>(data: &RecordBatch) -> Result<RecordBatc
     let mut columns = Vec::<Arc<dyn Array>>::with_capacity(data.columns().len());
 
     for col in data.columns().iter() {
-        if col.data_type() == &DataType::Binary {
+        if col.data_type() == &DataType::Binary || col.data_type() == &DataType::LargeBinary {
             columns.push(Arc::new(hex_encode_column::<PREFIXED>(
                 col.as_any().downcast_ref::<BinaryArray>().unwrap(),
             )));
@@ -200,7 +200,7 @@ pub fn schema_binary_to_string(schema: &Schema) -> Schema {
     let mut fields = Vec::<Arc<Field>>::with_capacity(schema.fields().len());
 
     for f in schema.fields().iter() {
-        if f.data_type() == &DataType::Binary {
+        if f.data_type() == &DataType::Binary || f.data_type() == &DataType::LargeBinary {
             fields.push(Arc::new(Field::new(
                 f.name().clone(),
                 DataType::Utf8,

--- a/python/cherry_core/__init__.py
+++ b/python/cherry_core/__init__.py
@@ -1,4 +1,4 @@
-from . import cherry_core as cc
+import cherry_core.cherry_core as cc
 from . import svm_decode
 from typing import Tuple
 import pyarrow

--- a/python/cherry_core/__init__.py
+++ b/python/cherry_core/__init__.py
@@ -80,17 +80,20 @@ def u256_column_to_binary(col: pyarrow.Array) -> pyarrow.Array:
 def u256_to_binary(data: pyarrow.RecordBatch) -> pyarrow.RecordBatch:
     return cc.u256_to_binary(data)
 
+
 def svm_decode_instructions(
     signature: svm_decode.InstructionSignature,
     batch: pyarrow.RecordBatch,
-    allow_decode_fail: bool = False
+    allow_decode_fail: bool = False,
 ) -> pyarrow.RecordBatch:
     return cc.svm_decode_instructions(signature, batch, allow_decode_fail)
+
 
 def instruction_signature_to_arrow_schema(
     signature: svm_decode.InstructionSignature,
 ) -> pyarrow.Schema:
     return cc.instruction_signature_to_arrow_schema(signature)
+
 
 def evm_decode_call_inputs(
     signature: str, data: pyarrow.Array, allow_decode_fail: bool = False

--- a/python/cherry_core/ingest/__init__.py
+++ b/python/cherry_core/ingest/__init__.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 import pyarrow
 from enum import Enum
 from . import evm, svm
-from .. import cc
+import cherry_core.cherry_core as cc
 
 
 class ProviderKind(str, Enum):

--- a/python/cherry_core/svm_decode/__init__.py
+++ b/python/cherry_core/svm_decode/__init__.py
@@ -1,50 +1,64 @@
 from typing import List, Optional, Union, TypeAlias, Literal
 from dataclasses import dataclass
 
-PrimitiveType: TypeAlias = Literal["i8", "i16", "i32", "i64", "i128", "u8", "u16", "u32", "u64", "u128", "bool"]
-ElementType: TypeAlias = Union[PrimitiveType, 'DynType', 'FixedArray', 'Array', 'Struct', 'Enum', 'Option']
+PrimitiveType: TypeAlias = Literal[
+    "i8", "i16", "i32", "i64", "i128", "u8", "u16", "u32", "u64", "u128", "bool"
+]
+ElementType: TypeAlias = Union[
+    PrimitiveType, "DynType", "FixedArray", "Array", "Struct", "Enum", "Option"
+]
+
 
 @dataclass
 class FixedArray:
     element_type: ElementType
     size: int
 
+
 @dataclass
 class Array:
     element_type: ElementType
+
 
 @dataclass
 class Field:
     name: str
     element_type: ElementType
 
+
 @dataclass
 class Struct:
     fields: List[Field]
+
 
 @dataclass
 class Variant:
     name: str
     element_type: Optional[ElementType]
 
+
 @dataclass
 class Enum:
     variants: List[Variant]
 
+
 @dataclass
 class Option:
     element_type: ElementType
-   
+
+
 @dataclass
 class ParamInput:
     name: str
     param_type: ElementType
+
 
 @dataclass
 class InstructionSignature:
     discriminator: str
     params: List[ParamInput]
     accounts_names: List[str]
+
 
 class DynType:
     I8: PrimitiveType = "i8"

--- a/python/cherry_core/svm_decode/__init__.py
+++ b/python/cherry_core/svm_decode/__init__.py
@@ -1,6 +1,5 @@
 from typing import List, Optional, Union, TypeAlias, Literal
 from dataclasses import dataclass
-from enum import Enum as PyEnum
 
 PrimitiveType: TypeAlias = Literal["i8", "i16", "i32", "i64", "i128", "u8", "u16", "u32", "u64", "u128", "bool"]
 ElementType: TypeAlias = Union[PrimitiveType, 'DynType', 'FixedArray', 'Array', 'Struct', 'Enum', 'Option']

--- a/python/cherry_core/svm_decode/__init__.py
+++ b/python/cherry_core/svm_decode/__init__.py
@@ -1,8 +1,9 @@
-from typing import List, Optional, Union, TypeAlias
+from typing import List, Optional, Union, TypeAlias, Literal
 from dataclasses import dataclass
-from enum import Enum
+from enum import Enum as PyEnum
 
-ElementType: TypeAlias = Union['DynType', 'FixedArray', 'Array', 'Struct', 'Enum', 'Option']
+PrimitiveType: TypeAlias = Literal["i8", "i16", "i32", "i64", "i128", "u8", "u16", "u32", "u64", "u128", "bool"]
+ElementType: TypeAlias = Union[PrimitiveType, 'DynType', 'FixedArray', 'Array', 'Struct', 'Enum', 'Option']
 
 @dataclass
 class FixedArray:
@@ -42,22 +43,22 @@ class ParamInput:
 
 @dataclass
 class InstructionSignature:
-    discriminator: bytes
+    discriminator: str
     params: List[ParamInput]
     accounts_names: List[str]
 
 class DynType:
-    I8 = "i8"
-    I16 = "i16"
-    I32 = "i32"
-    I64 = "i64"
-    I128 = "i128"
-    U8 = "u8"
-    U16 = "u16"
-    U32 = "u32"
-    U64 = "u64"
-    U128 = "u128"
-    Bool = "bool"
+    I8: PrimitiveType = "i8"
+    I16: PrimitiveType = "i16"
+    I32: PrimitiveType = "i32"
+    I64: PrimitiveType = "i64"
+    I128: PrimitiveType = "i128"
+    U8: PrimitiveType = "u8"
+    U16: PrimitiveType = "u16"
+    U32: PrimitiveType = "u32"
+    U64: PrimitiveType = "u64"
+    U128: PrimitiveType = "u128"
+    Bool: PrimitiveType = "bool"
     FixedArray = FixedArray
     Array = Array
     Struct = Struct

--- a/python/examples/svm_decode.py
+++ b/python/examples/svm_decode.py
@@ -17,194 +17,414 @@ print(f"Will save output to: {output_file}")
 try:
     # Read the input Parquet file
     table = pq.read_table(str(input_file))
-    
+
     # Convert to RecordBatch
     batch = table.to_batches()[0]
-    
+
     # Create the instruction signature using the new classes
     # For SPL Token Transfer
-    
+
     signature = InstructionSignature(
-        discriminator = "fKVLd548UPT",
-        params = [
+        discriminator="fKVLd548UPT",
+        params=[
             ParamInput(
                 name="RoutePlan",
-                param_type=DynType.Array(DynType.Struct([
-                    Field(
-                        name="Swap",
-                        element_type=DynType.Enum([
-                            Variant("Saber", None),
-                            Variant("SaberAddDecimalsDeposit", None),
-                            Variant("SaberAddDecimalsWithdraw", None),
-                            Variant("TokenSwap", None),
-                            Variant("Sencha", None),
-                            Variant("Step", None),
-                            Variant("Cropper", None),
-                            Variant("Raydium", None),
-                            Variant("Crema", DynType.Struct([
-                                Field("a_to_b", DynType.Bool),
-                            ])),
-                            Variant("Lifinity", None),
-                            Variant("Mercurial", None),
-                            Variant("Cykura", None),
-                            Variant("Serum", DynType.Struct([
-                                Field("side", DynType.Enum([
-                                    Variant("Bid", None),
-                                    Variant("Ask", None)
-                                ])),
-                            ])),
-                            Variant("MarinadeDeposit", None),
-                            Variant("MarinadeUnstake", None),
-                            Variant("Aldrin", DynType.Struct([
-                                Field("side", DynType.Enum([
-                                    Variant("Bid", None),
-                                    Variant("Ask", None),
-                                ])),
-                            ])),
-                            Variant("AldrinV2", DynType.Struct([
-                                Field("side", DynType.Enum([
-                                    Variant("Bid", None),
-                                    Variant("Ask", None),
-                                ])),
-                            ])),
-                            Variant("Whirlpool", DynType.Struct([
-                                Field("a_to_b", DynType.Bool),
-                            ])),
-                            Variant("Invariant", DynType.Struct([
-                                Field("x_to_y", DynType.Bool),
-                            ])),
-                            Variant("Meteora", None),
-                            Variant("GooseFX", None),
-                            Variant("DeltaFi", DynType.Struct([
-                                Field("stable", DynType.Bool),
-                            ])),
-                            Variant("Balansol", None),
-                            Variant("MarcoPolo", DynType.Struct([
-                                Field("x_to_y", DynType.Bool),
-                            ])),
-                            Variant("Dradex", DynType.Struct([
-                                Field("side", DynType.Enum([
-                                    Variant("Bid", None),
-                                    Variant("Ask", None),
-                                ])),
-                            ])),
-                            Variant("LifinityV2", None),
-                            Variant("RaydiumClmm", None),
-                            Variant("Openbook", DynType.Struct([
-                                Field("side", DynType.Enum([
-                                    Variant("Bid", None),
-                                    Variant("Ask", None),
-                                ])),
-                            ])),
-                            Variant("Phoenix", DynType.Struct([
-                                Field("side", DynType.Enum([
-                                    Variant("Bid", None),
-                                    Variant("Ask", None),
-                                ])),
-                            ])),
-                            Variant("Symmetry", DynType.Struct([
-                                Field("from_token_id", DynType.U64),
-                                Field("to_token_id", DynType.U64),
-                            ])),
-                            Variant("TokenSwapV2", None),
-                            Variant("HeliumTreasuryManagementRedeemV0", None),
-                            Variant("StakeDexStakeWrappedSol", None),
-                            Variant("StakeDexSwapViaStake", DynType.Struct([
-                                Field("bridge_stake_seed", DynType.U32),
-                            ])),
-                            Variant("GooseFXV2", None),
-                            Variant("Perps", None),
-                            Variant("PerpsAddLiquidity", None),
-                            Variant("PerpsRemoveLiquidity", None),
-                            Variant("MeteoraDlmm", None),
-                            Variant("OpenBookV2", DynType.Struct([
-                                Field("side", DynType.Enum([
-                                    Variant("Bid", None),
-                                    Variant("Ask", None),
-                                ])),
-                            ])),
-                            Variant("RaydiumClmmV2", None),
-                            Variant("StakeDexPrefundWithdrawStakeAndDepositStake", DynType.Struct([
-                                Field("bridge_stake_seed", DynType.U32),
-                            ])),
-                            Variant("Clone", DynType.Struct([
-                                Field("pool_index", DynType.U8),
-                                Field("quantity_is_input", DynType.Bool),
-                                Field("quantity_is_collateral", DynType.Bool),
-                            ])),
-                            Variant("SanctumS", DynType.Struct([
-                                Field("src_lst_value_calc_accs", DynType.U8),
-                                Field("dst_lst_value_calc_accs", DynType.U8),
-                                Field("src_lst_index", DynType.U32),
-                                Field("dst_lst_index", DynType.U32),
-                            ])),
-                            Variant("SanctumSAddLiquidity", DynType.Struct([
-                                Field("lst_value_calc_accs", DynType.U8),
-                                Field("lst_index", DynType.U32),
-                            ])),
-                            Variant("SanctumSRemoveLiquidity", DynType.Struct([
-                                Field("lst_value_calc_accs", DynType.U8),
-                                Field("lst_index", DynType.U32),
-                            ])),
-                            Variant("RaydiumCP", None),
-                            Variant("WhirlpoolSwapV2", DynType.Struct([
-                                Field("a_to_b", DynType.Bool),
-                                Field("remaining_accounts_info", DynType.Struct([
-                                    Field("slices", DynType.Array(DynType.Struct([
-                                        Field("remaining_accounts_slice", DynType.Struct([
-                                            Field("accounts_type", DynType.U8),
-                                            Field("length", DynType.U8),
-                                        ]))
-                                    ]))),
-                                ])),
-                            ])),
-                            Variant("OneIntro", None),
-                            Variant("PumpdotfunWrappedBuy", None),
-                            Variant("PumpdotfunWrappedSell", None),
-                            Variant("PerpsV2", None),
-                            Variant("PerpsV2AddLiquidity", None),
-                            Variant("PerpsV2RemoveLiquidity", None),
-                            Variant("MoonshotWrappedBuy", None),
-                            Variant("MoonshotWrappedSell", None),
-                            Variant("StabbleStableSwap", None),
-                            Variant("StabbleWeightedSwap", None),
-                            Variant("Obric", DynType.Struct([
-                                Field("x_to_y", DynType.Bool),
-                            ])),
-                            Variant("FoxBuyFromEstimatedCost", None),
-                            Variant("FoxClaimPartial", DynType.Struct([
-                                Field("is_y", DynType.Bool),
-                            ])),
-                            Variant("SolFi", DynType.Struct([
-                                Field("is_quote_to_base", DynType.Bool),
-                            ])),
-                            Variant("SolayerDelegateNoInit", None),
-                            Variant("SolayerUndelegateNoInit", None),
-                            Variant("TokenMill", DynType.Struct([
-                                Field("side", DynType.Enum([
-                                    Variant("Bid", None),
-                                    Variant("Ask", None),
-                                ])),
-                            ])),
-                            Variant("DaosFunBuy", None),
-                            Variant("DaosFunSell", None),
-                            Variant("ZeroFi", None),
-                            Variant("StakeDexWithdrawWrappedSol", None),
-                            Variant("VirtualsBuy", None),
-                            Variant("VirtualsSell", None),
-                            Variant("Peren", DynType.Struct([
-                                Field("in_index", DynType.U8),
-                                Field("out_index", DynType.U8),
-                            ])),
-                            Variant("PumpdotfunAmmBuy", None),
-                            Variant("PumpdotfunAmmSell", None),
-                            Variant("Gamma", None),
-                        ])
-                    ),
-                    Field("Percent", DynType.U8),
-                    Field("InputIndex", DynType.U8),
-                    Field("OutputIndex", DynType.U8),
-                ]))
+                param_type=DynType.Array(
+                    DynType.Struct(
+                        [
+                            Field(
+                                name="Swap",
+                                element_type=DynType.Enum(
+                                    [
+                                        Variant("Saber", None),
+                                        Variant("SaberAddDecimalsDeposit", None),
+                                        Variant("SaberAddDecimalsWithdraw", None),
+                                        Variant("TokenSwap", None),
+                                        Variant("Sencha", None),
+                                        Variant("Step", None),
+                                        Variant("Cropper", None),
+                                        Variant("Raydium", None),
+                                        Variant(
+                                            "Crema",
+                                            DynType.Struct(
+                                                [
+                                                    Field("a_to_b", DynType.Bool),
+                                                ]
+                                            ),
+                                        ),
+                                        Variant("Lifinity", None),
+                                        Variant("Mercurial", None),
+                                        Variant("Cykura", None),
+                                        Variant(
+                                            "Serum",
+                                            DynType.Struct(
+                                                [
+                                                    Field(
+                                                        "side",
+                                                        DynType.Enum(
+                                                            [
+                                                                Variant("Bid", None),
+                                                                Variant("Ask", None),
+                                                            ]
+                                                        ),
+                                                    ),
+                                                ]
+                                            ),
+                                        ),
+                                        Variant("MarinadeDeposit", None),
+                                        Variant("MarinadeUnstake", None),
+                                        Variant(
+                                            "Aldrin",
+                                            DynType.Struct(
+                                                [
+                                                    Field(
+                                                        "side",
+                                                        DynType.Enum(
+                                                            [
+                                                                Variant("Bid", None),
+                                                                Variant("Ask", None),
+                                                            ]
+                                                        ),
+                                                    ),
+                                                ]
+                                            ),
+                                        ),
+                                        Variant(
+                                            "AldrinV2",
+                                            DynType.Struct(
+                                                [
+                                                    Field(
+                                                        "side",
+                                                        DynType.Enum(
+                                                            [
+                                                                Variant("Bid", None),
+                                                                Variant("Ask", None),
+                                                            ]
+                                                        ),
+                                                    ),
+                                                ]
+                                            ),
+                                        ),
+                                        Variant(
+                                            "Whirlpool",
+                                            DynType.Struct(
+                                                [
+                                                    Field("a_to_b", DynType.Bool),
+                                                ]
+                                            ),
+                                        ),
+                                        Variant(
+                                            "Invariant",
+                                            DynType.Struct(
+                                                [
+                                                    Field("x_to_y", DynType.Bool),
+                                                ]
+                                            ),
+                                        ),
+                                        Variant("Meteora", None),
+                                        Variant("GooseFX", None),
+                                        Variant(
+                                            "DeltaFi",
+                                            DynType.Struct(
+                                                [
+                                                    Field("stable", DynType.Bool),
+                                                ]
+                                            ),
+                                        ),
+                                        Variant("Balansol", None),
+                                        Variant(
+                                            "MarcoPolo",
+                                            DynType.Struct(
+                                                [
+                                                    Field("x_to_y", DynType.Bool),
+                                                ]
+                                            ),
+                                        ),
+                                        Variant(
+                                            "Dradex",
+                                            DynType.Struct(
+                                                [
+                                                    Field(
+                                                        "side",
+                                                        DynType.Enum(
+                                                            [
+                                                                Variant("Bid", None),
+                                                                Variant("Ask", None),
+                                                            ]
+                                                        ),
+                                                    ),
+                                                ]
+                                            ),
+                                        ),
+                                        Variant("LifinityV2", None),
+                                        Variant("RaydiumClmm", None),
+                                        Variant(
+                                            "Openbook",
+                                            DynType.Struct(
+                                                [
+                                                    Field(
+                                                        "side",
+                                                        DynType.Enum(
+                                                            [
+                                                                Variant("Bid", None),
+                                                                Variant("Ask", None),
+                                                            ]
+                                                        ),
+                                                    ),
+                                                ]
+                                            ),
+                                        ),
+                                        Variant(
+                                            "Phoenix",
+                                            DynType.Struct(
+                                                [
+                                                    Field(
+                                                        "side",
+                                                        DynType.Enum(
+                                                            [
+                                                                Variant("Bid", None),
+                                                                Variant("Ask", None),
+                                                            ]
+                                                        ),
+                                                    ),
+                                                ]
+                                            ),
+                                        ),
+                                        Variant(
+                                            "Symmetry",
+                                            DynType.Struct(
+                                                [
+                                                    Field("from_token_id", DynType.U64),
+                                                    Field("to_token_id", DynType.U64),
+                                                ]
+                                            ),
+                                        ),
+                                        Variant("TokenSwapV2", None),
+                                        Variant(
+                                            "HeliumTreasuryManagementRedeemV0", None
+                                        ),
+                                        Variant("StakeDexStakeWrappedSol", None),
+                                        Variant(
+                                            "StakeDexSwapViaStake",
+                                            DynType.Struct(
+                                                [
+                                                    Field(
+                                                        "bridge_stake_seed", DynType.U32
+                                                    ),
+                                                ]
+                                            ),
+                                        ),
+                                        Variant("GooseFXV2", None),
+                                        Variant("Perps", None),
+                                        Variant("PerpsAddLiquidity", None),
+                                        Variant("PerpsRemoveLiquidity", None),
+                                        Variant("MeteoraDlmm", None),
+                                        Variant(
+                                            "OpenBookV2",
+                                            DynType.Struct(
+                                                [
+                                                    Field(
+                                                        "side",
+                                                        DynType.Enum(
+                                                            [
+                                                                Variant("Bid", None),
+                                                                Variant("Ask", None),
+                                                            ]
+                                                        ),
+                                                    ),
+                                                ]
+                                            ),
+                                        ),
+                                        Variant("RaydiumClmmV2", None),
+                                        Variant(
+                                            "StakeDexPrefundWithdrawStakeAndDepositStake",
+                                            DynType.Struct(
+                                                [
+                                                    Field(
+                                                        "bridge_stake_seed", DynType.U32
+                                                    ),
+                                                ]
+                                            ),
+                                        ),
+                                        Variant(
+                                            "Clone",
+                                            DynType.Struct(
+                                                [
+                                                    Field("pool_index", DynType.U8),
+                                                    Field(
+                                                        "quantity_is_input",
+                                                        DynType.Bool,
+                                                    ),
+                                                    Field(
+                                                        "quantity_is_collateral",
+                                                        DynType.Bool,
+                                                    ),
+                                                ]
+                                            ),
+                                        ),
+                                        Variant(
+                                            "SanctumS",
+                                            DynType.Struct(
+                                                [
+                                                    Field(
+                                                        "src_lst_value_calc_accs",
+                                                        DynType.U8,
+                                                    ),
+                                                    Field(
+                                                        "dst_lst_value_calc_accs",
+                                                        DynType.U8,
+                                                    ),
+                                                    Field("src_lst_index", DynType.U32),
+                                                    Field("dst_lst_index", DynType.U32),
+                                                ]
+                                            ),
+                                        ),
+                                        Variant(
+                                            "SanctumSAddLiquidity",
+                                            DynType.Struct(
+                                                [
+                                                    Field(
+                                                        "lst_value_calc_accs",
+                                                        DynType.U8,
+                                                    ),
+                                                    Field("lst_index", DynType.U32),
+                                                ]
+                                            ),
+                                        ),
+                                        Variant(
+                                            "SanctumSRemoveLiquidity",
+                                            DynType.Struct(
+                                                [
+                                                    Field(
+                                                        "lst_value_calc_accs",
+                                                        DynType.U8,
+                                                    ),
+                                                    Field("lst_index", DynType.U32),
+                                                ]
+                                            ),
+                                        ),
+                                        Variant("RaydiumCP", None),
+                                        Variant(
+                                            "WhirlpoolSwapV2",
+                                            DynType.Struct(
+                                                [
+                                                    Field("a_to_b", DynType.Bool),
+                                                    Field(
+                                                        "remaining_accounts_info",
+                                                        DynType.Struct(
+                                                            [
+                                                                Field(
+                                                                    "slices",
+                                                                    DynType.Array(
+                                                                        DynType.Struct(
+                                                                            [
+                                                                                Field(
+                                                                                    "remaining_accounts_slice",
+                                                                                    DynType.Struct(
+                                                                                        [
+                                                                                            Field(
+                                                                                                "accounts_type",
+                                                                                                DynType.U8,
+                                                                                            ),
+                                                                                            Field(
+                                                                                                "length",
+                                                                                                DynType.U8,
+                                                                                            ),
+                                                                                        ]
+                                                                                    ),
+                                                                                )
+                                                                            ]
+                                                                        )
+                                                                    ),
+                                                                ),
+                                                            ]
+                                                        ),
+                                                    ),
+                                                ]
+                                            ),
+                                        ),
+                                        Variant("OneIntro", None),
+                                        Variant("PumpdotfunWrappedBuy", None),
+                                        Variant("PumpdotfunWrappedSell", None),
+                                        Variant("PerpsV2", None),
+                                        Variant("PerpsV2AddLiquidity", None),
+                                        Variant("PerpsV2RemoveLiquidity", None),
+                                        Variant("MoonshotWrappedBuy", None),
+                                        Variant("MoonshotWrappedSell", None),
+                                        Variant("StabbleStableSwap", None),
+                                        Variant("StabbleWeightedSwap", None),
+                                        Variant(
+                                            "Obric",
+                                            DynType.Struct(
+                                                [
+                                                    Field("x_to_y", DynType.Bool),
+                                                ]
+                                            ),
+                                        ),
+                                        Variant("FoxBuyFromEstimatedCost", None),
+                                        Variant(
+                                            "FoxClaimPartial",
+                                            DynType.Struct(
+                                                [
+                                                    Field("is_y", DynType.Bool),
+                                                ]
+                                            ),
+                                        ),
+                                        Variant(
+                                            "SolFi",
+                                            DynType.Struct(
+                                                [
+                                                    Field(
+                                                        "is_quote_to_base", DynType.Bool
+                                                    ),
+                                                ]
+                                            ),
+                                        ),
+                                        Variant("SolayerDelegateNoInit", None),
+                                        Variant("SolayerUndelegateNoInit", None),
+                                        Variant(
+                                            "TokenMill",
+                                            DynType.Struct(
+                                                [
+                                                    Field(
+                                                        "side",
+                                                        DynType.Enum(
+                                                            [
+                                                                Variant("Bid", None),
+                                                                Variant("Ask", None),
+                                                            ]
+                                                        ),
+                                                    ),
+                                                ]
+                                            ),
+                                        ),
+                                        Variant("DaosFunBuy", None),
+                                        Variant("DaosFunSell", None),
+                                        Variant("ZeroFi", None),
+                                        Variant("StakeDexWithdrawWrappedSol", None),
+                                        Variant("VirtualsBuy", None),
+                                        Variant("VirtualsSell", None),
+                                        Variant(
+                                            "Peren",
+                                            DynType.Struct(
+                                                [
+                                                    Field("in_index", DynType.U8),
+                                                    Field("out_index", DynType.U8),
+                                                ]
+                                            ),
+                                        ),
+                                        Variant("PumpdotfunAmmBuy", None),
+                                        Variant("PumpdotfunAmmSell", None),
+                                        Variant("Gamma", None),
+                                    ]
+                                ),
+                            ),
+                            Field("Percent", DynType.U8),
+                            Field("InputIndex", DynType.U8),
+                            Field("OutputIndex", DynType.U8),
+                        ]
+                    )
+                ),
             ),
             ParamInput(
                 name="InAmount",
@@ -232,22 +452,22 @@ try:
             "PlatformFeeAccount",
             "EventAuthority",
             "Program",
-        ]           
+        ],
     )
-    
+
     # Decode the instruction batch
     print("Decoding instruction batch...")
     decoded_batch = svm_decode_instructions(signature, batch, True)
-    
+
     # Convert RecordBatch to Table before writing
     decoded_table = pa.Table.from_batches([decoded_batch])
-    
+
     # Save the decoded result to a new Parquet file
     print("Saving decoded result...")
     pq.write_table(decoded_table, str(output_file))
-    
+
     print("Successfully decoded and saved the result!")
-    
+
 except Exception as e:
     print(f"Error during decoding: {e}")
     raise

--- a/svm-decode/src/lib.rs
+++ b/svm-decode/src/lib.rs
@@ -157,6 +157,13 @@ pub fn decode_instructions(
 
 pub fn match_discriminators(instr_data: &[u8], discriminator: &[u8]) -> Result<Vec<u8>> {
     let discriminator_len = discriminator.len();
+    if instr_data.len() < discriminator_len {
+        return Err(anyhow::anyhow!(
+            "Instruction data is too short to contain discriminator. Expected at least {} bytes, got {} bytes",
+            discriminator_len,
+            instr_data.len()
+        ));
+    }
     let disc = &instr_data[..discriminator_len].to_vec();
     let ix_data = &instr_data[discriminator_len..];
     if !disc.eq(discriminator) {


### PR DESCRIPTION
This PR is doing 3 things:

In svm-dedode: Small fix for a bug, because it was hard to identify this error in cherry (python)

In Cast:  It's fixing the functions that receive `&RecordBatch` as inputs, to don't differentiate between col of `&DataType::Binary` and `&DataType::LargeBinary`. This will fix, base58_encode, hex_encode, schema_binary_to_string. It won't fix the functions that takes `BinaryArray` as input, that require generics.

In Python: It fix the lint error, that are not being checked in this repo but is affecting cherry. We should add python lint in CI for this repo as well.
