### PR TITLE
Add functions to retrieve V2 like pool tokens and their table representation

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cherry-core"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 description = "Core library for cherry blockchain data framework"
 homepage = "https://github.com/steelcake/cherry-core"
@@ -17,7 +17,7 @@ cherry-evm-schema = { path = "../evm-schema", version = "0.1.0" }
 cherry-svm-schema = { path = "../svm-schema", version = "0.1.0" }
 cherry-ingest = { path = "../ingest", version ="0.4.0" }
 cherry-query = { path = "../query", version = "0.2.0" }
-cherry-rpc-call = { path = "../rpc_call", version = "0.2.0" }
+cherry-rpc-call = { path = "../rpc_call", version = "0.2.1" }
 
 [dev-dependencies]
 hypersync-client = { workspace = true } 

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cherry-core-python"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 description = "Core library for cherry blockchain data framework"
 homepage = "https://github.com/steelcake/cherry-core"

--- a/python/cherry_core/__init__.py
+++ b/python/cherry_core/__init__.py
@@ -176,3 +176,13 @@ def get_token_metadata_as_table(
     },
 ) -> pyarrow.Table:
     return cc.get_token_metadata_as_table(rpc_url, addresses, selector)
+
+
+def get_v2_pool_tokens(rpc_url: str, pool_addresses: list[str]) -> list[dict]:
+    return cc.get_v2_pool_tokens(rpc_url, pool_addresses)
+
+
+def get_v2_pool_tokens_as_table(
+    rpc_url: str, pool_addresses: list[str]
+) -> pyarrow.Table:
+    return cc.get_v2_pool_tokens_as_table(rpc_url, pool_addresses)

--- a/python/cherry_core/__init__.py
+++ b/python/cherry_core/__init__.py
@@ -178,11 +178,11 @@ def get_token_metadata_as_table(
     return cc.get_token_metadata_as_table(rpc_url, addresses, selector)
 
 
-def get_v2_pool_tokens(rpc_url: str, pool_addresses: list[str]) -> list[dict]:
-    return cc.get_v2_pool_tokens(rpc_url, pool_addresses)
+def get_pools_token0_token1(rpc_url: str, pool_addresses: list[str]) -> list[dict]:
+    return cc.get_pools_token0_token1(rpc_url, pool_addresses)
 
 
-def get_v2_pool_tokens_as_table(
+def get_pools_token0_token1_as_table(
     rpc_url: str, pool_addresses: list[str]
 ) -> pyarrow.Table:
-    return cc.get_v2_pool_tokens_as_table(rpc_url, pool_addresses)
+    return cc.get_pools_token0_token1_as_table(rpc_url, pool_addresses)

--- a/python/examples/v2_pool_tokens.py
+++ b/python/examples/v2_pool_tokens.py
@@ -1,0 +1,35 @@
+import cherry_core
+import polars as pl
+
+
+def main():
+    # Test addresses including invalid and valid ones
+    pool_addresses = [
+        "Invalid address",
+        "0xfBB6Eed8e7aa03B138556eeDaF5D271A5E1e43ef",  # cbBTC/USDC on uniswap v3
+        "0x31f609019d0CC0b8cC865656142d6FeD69853689",  # POPCAT/WETH on uniswap v2
+        "0x6cDcb1C4A4D1C3C6d054b27AC5B77e89eAFb971d",  # AERO/USDC on Aerodrome
+        "0x323b43332F97B1852D8567a08B1E8ed67d25A8d5",  # msETH/WETH on Pancake Swap
+    ]
+
+    # Test get_v2_pool_tokens
+    print("Testing get_v2_pool_tokens:")
+    pool_tokens = cherry_core.get_v2_pool_tokens("https://base-rpc.publicnode.com", pool_addresses)
+    print("Pool tokens as list of dictionaries:")
+    for pool in pool_tokens:
+        print(pool)
+    print("\n")
+
+    # Test get_v2_pool_tokens_as_table
+    print("Testing get_v2_pool_tokens_as_table:")
+    pool_tokens_table = cherry_core.get_v2_pool_tokens_as_table(
+        "https://base-rpc.publicnode.com", pool_addresses
+    )
+    # Convert to polars DataFrame for better display
+    df = pl.from_arrow(pool_tokens_table)
+    print("Pool tokens as table:")
+    print(df)
+
+
+if __name__ == "__main__":
+    main()

--- a/python/examples/v2_pool_tokens.py
+++ b/python/examples/v2_pool_tokens.py
@@ -12,17 +12,19 @@ def main():
         "0x323b43332F97B1852D8567a08B1E8ed67d25A8d5",  # msETH/WETH on Pancake Swap
     ]
 
-    # Test get_v2_pool_tokens
-    print("Testing get_v2_pool_tokens:")
-    pool_tokens = cherry_core.get_v2_pool_tokens("https://base-rpc.publicnode.com", pool_addresses)
+    # Test get_pools_token0_token1
+    print("Testing get_pools_token0_token1:")
+    pool_tokens = cherry_core.get_pools_token0_token1(
+        "https://base-rpc.publicnode.com", pool_addresses
+    )
     print("Pool tokens as list of dictionaries:")
     for pool in pool_tokens:
         print(pool)
     print("\n")
 
-    # Test get_v2_pool_tokens_as_table
-    print("Testing get_v2_pool_tokens_as_table:")
-    pool_tokens_table = cherry_core.get_v2_pool_tokens_as_table(
+    # Test get_pools_token0_token1_as_table
+    print("Testing get_pools_token0_token1_as_table:")
+    pool_tokens_table = cherry_core.get_pools_token0_token1_as_table(
         "https://base-rpc.publicnode.com", pool_addresses
     )
     # Convert to polars DataFrame for better display

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -61,8 +61,8 @@ fn cherry_core(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(base58_decode_string, m)?)?;
     m.add_function(wrap_pyfunction!(get_token_metadata, m)?)?;
     m.add_function(wrap_pyfunction!(get_token_metadata_as_table, m)?)?;
-    m.add_function(wrap_pyfunction!(get_v2_pool_tokens, m)?)?;
-    m.add_function(wrap_pyfunction!(get_v2_pool_tokens_as_table, m)?)?;
+    m.add_function(wrap_pyfunction!(get_pools_token0_token1, m)?)?;
+    m.add_function(wrap_pyfunction!(get_pools_token0_token1_as_table, m)?)?;
     ingest::ingest_module(py, m)?;
 
     Ok(())
@@ -673,13 +673,13 @@ fn get_token_metadata_as_table(
 }
 
 #[pyfunction]
-fn get_v2_pool_tokens(
+fn get_pools_token0_token1(
     rpc_url: &str,
     pool_addresses: Vec<String>,
     py: Python<'_>,
 ) -> PyResult<PyObject> {
     let pool_tokens = TOKIO_RUNTIME.block_on(async {
-        baselib::rpc_call::get_v2_pool_tokens(rpc_url, pool_addresses).await
+        baselib::rpc_call::get_pools_token0_token1(rpc_url, pool_addresses).await
     })?;
     let py_list = PyList::empty(py);
 
@@ -708,13 +708,13 @@ fn get_v2_pool_tokens(
 }
 
 #[pyfunction]
-fn get_v2_pool_tokens_as_table(
+fn get_pools_token0_token1_as_table(
     rpc_url: &str,
     pool_addresses: Vec<String>,
     py: Python<'_>,
 ) -> PyResult<PyObject> {
     let pool_tokens = TOKIO_RUNTIME.block_on(async {
-        baselib::rpc_call::get_v2_pool_tokens(rpc_url, pool_addresses).await
+        baselib::rpc_call::get_pools_token0_token1(rpc_url, pool_addresses).await
     })?;
     let batch = baselib::rpc_call::v2_pool_tokens_to_table(pool_tokens)?;
 

--- a/rpc_call/Cargo.toml
+++ b/rpc_call/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cherry-rpc-call"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "RPC call executor for cherry"
 homepage = "https://github.com/steelcake/cherry-core"


### PR DESCRIPTION
- Implemented `get_v2_pool_tokens` and `get_v2_pool_tokens_as_table` in `cherry_core`.
- Added a new example script `v2_pool_tokens.py` to demonstrate usage of the new functions.
- Updated Rust bindings to expose the new functions to Python.